### PR TITLE
Added browser list for pspdfkit 2020.6.3

### DIFF
--- a/data/pspdfkit/2020.6.3.json
+++ b/data/pspdfkit/2020.6.3.json
@@ -1,0 +1,34 @@
+{
+  "supportedBrowsers": [
+    "and_chr 81",
+    "chrome 83",
+    "chrome 81",
+    "edge 83",
+    "edge 81",
+    "edge 18",
+    "firefox 76",
+    "firefox 75",
+    "firefox 68",
+    "ie 11",
+    "ios_saf 13.4-13.5",
+    "ios_saf 13.3",
+    "safari 13.1",
+    "safari 13"
+  ],
+  "config": [
+    "last 2 Chrome versions",
+    "last 2 firefox versions",
+    "last 2 edge versions",
+    "last 2 safari versions",
+    "Firefox ESR",
+    "IE 11",
+    "last 2 and_chr versions",
+    "last 2 ios_saf versions",
+    "edge 18"
+  ],
+  "title": "Browsers supported by PSPDFKit for Web",
+  "browserslist": "4.12.0",
+  "caniuse": "1.0.30001081",
+  "version": "2020.6.3"
+}
+


### PR DESCRIPTION
Updated browser list for pspdfkit 2020.6.3

**Basecamp project:** https://3.basecamp.com/3755195/buckets/19814271/todos/3248673097