### PR TITLE
Update caniuse-lite to 1.0.30001235

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,9 +2992,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001043, caniuse-lite@^1.0.30001093:
-  version "1.0.30001235"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz"
-  integrity sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==
+  version "1.0.30001240"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001240.tgz"
+  integrity sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==
 
 caw@^2.0.0, caw@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,9 +2992,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001043, caniuse-lite@^1.0.30001093:
-  version "1.0.30001157"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz"
-  integrity sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==
+  version "1.0.30001235"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz"
+  integrity sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==
 
 caw@^2.0.0, caw@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Updates the (very) outdated `caniuse-lite` to the latest version. Closes #25 

```diff
Target browser changes:
- and_chr 86
+ and_chr 90
- and_ff 82
+ and_ff 87
- android 81
+ android 90
- chrome 86
- chrome 85
- chrome 84
+ chrome 91
+ chrome 90
+ chrome 89
- edge 86
- edge 85
+ edge 91
+ edge 90
- firefox 82
- firefox 81
+ firefox 89
+ firefox 88
- ios_saf 14
- ios_saf 13.3
- ios_saf 12.2-12.4
+ ios_saf 14.5-14.6
+ ios_saf 14.0-14.4
- op_mob 59
+ op_mob 62
- opera 72
- opera 71
+ opera 76
+ opera 75
- safari 13.1
+ safari 14.1
- samsung 12.0
- samsung 11.1-11.2
+ samsung 14.0
+ samsung 13.0
```