### PR TITLE
added browser list for pspdfkit 2022.5.0

### DIFF
--- a/data/pspdfkit/2022.5.0.json
+++ b/data/pspdfkit/2022.5.0.json
@@ -1,0 +1,33 @@
+{
+  "supportedBrowsers": [
+    "and_chr 102",
+    "chrome 102",
+    "chrome 101",
+    "edge 102",
+    "edge 101",
+    "edge 18",
+    "firefox 101",
+    "firefox 100",
+    "firefox 91",
+    "firefox 78",
+    "ios_saf 15.5",
+    "ios_saf 15.4",
+    "safari 15.5",
+    "safari 15.4"
+  ],
+  "config": [
+    "Firefox ESR",
+    "edge 18",
+    "last 2 Chrome versions",
+    "last 2 firefox versions",
+    "last 2 edge versions",
+    "last 2 safari versions",
+    "last 2 and_chr versions",
+    "last 2 ios_saf versions"
+  ],
+  "title": "Browsers supported by PSPDFKit for Web",
+  "browserslist": "4.19.1",
+  "caniuse": "1.0.30001349",
+  "version": "2022.5.0"
+}
+


### PR DESCRIPTION
use the correct year in version 